### PR TITLE
Pass NULL pointer to lpCompletionRoutine

### DIFF
--- a/lib/Filesys/Notify/Win32/ReadDirectoryChanges.pm
+++ b/lib/Filesys/Notify/Win32/ReadDirectoryChanges.pm
@@ -152,7 +152,7 @@ sub _ReadDirectoryChangesW( $hDirectory, $watchSubTree, $filter ) {
         $filter,
         $returnBufferSize,
         undef,
-        undef);
+        0);
     if( $r ) {
         return substr $buffer, 0, $returnBufferSize;
     } else {


### PR DESCRIPTION
This seems to fix the spurious warnings "The handle is invalid" for error code 0x6.

I don't know enough about `Win32::API` to fully understand what the difference between 0 und `undef` is in this call but it fixes the problem with the invalid handle. I tried that out after reading this post on stackoverflow: https://stackoverflow.com/questions/40193431/readdirectorychangesw-rejecting-handle-accepted-by-createiocompletionport

If you want to reproduce the problem with the test suite of https://github.com/gflohr/AnyEvent-Filesys-Watcher you either have to comment out the "skip all" from the test `t/34-parse-events.t` (and others) or go back commit 2d0189692471bd71a8a137f865ffed6e42163d77. After that I disabled the tests so that the build pipelines succeed.